### PR TITLE
Improve site navigation and news coverage

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center h-20">
                 <!-- ロゴ --><div class="flex-shrink-0">
-                    <a href="#" class="flex items-center">
+                    <a href="index.html" class="flex items-center">
                         <span class="text-2xl font-black text-heavy-blue">SSC |</span>
                         <span class="text-xl font-bold text-gray-700 ml-2">Sayo Social Connect</span>
                     </a>
@@ -70,7 +70,7 @@
             <a href="pages/jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="pages/solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="pages/saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="#contact" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="pages/toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -104,7 +104,7 @@
             </div>
         </section>
 
-        <!-- 3. お知らせ (News) --><section class="py-16 bg-gray-50">
+        <!-- 3. お知らせ (News) --><section id="news" class="py-16 bg-gray-50">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8">
                 <h2 class="text-3xl font-bold text-center text-heavy-blue mb-8">お知らせ（新着）</h2>
                 <div class="max-w-3xl mx-auto bg-white shadow-lg rounded-lg overflow-hidden">
@@ -112,7 +112,7 @@
                         <li class="flex flex-col sm:flex-row p-4 hover:bg-gray-50 transition duration-300">
                             <span class="font-semibold text-gray-600 w-full sm:w-32 mb-1 sm:mb-0">2025.10.26</span>
                             <span class="flex-1 text-gray-800">
-                                <a href="#" class="hover:underline">コーポレートサイトをリニューアルしました。</a>
+                                <a href="pages/oshirase/2025-10-26-renewal.html" class="hover:underline">コーポレートサイトをリニューアルしました。</a>
                             </span>
                         </li>
                         <li class="flex flex-col sm:flex-row p-4 hover:bg-gray-50 transition duration-300">
@@ -132,7 +132,7 @@
                         -->
                     </ul>
                     <div class="text-right p-4 bg-gray-50">
-                        <a href="#" class="font-bold text-heavy-blue hover:text-accent-blue transition duration-300">
+                        <a href="pages/oshirase/index.html" class="font-bold text-heavy-blue hover:text-accent-blue transition duration-300">
                             お知らせ一覧へ &rarr;
                         </a>
                     </div>
@@ -157,7 +157,7 @@
                             <p class="text-gray-600 text-sm mb-4">
                                 基幹システムの開発から運用保守まで、企業のビジネスを加速させるIT戦略を支援します。
                             </p>
-                            <a href="#" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
+                            <a href="pages/jigyounaiyou.html#enterprise" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
                         </div>
                     </div>
                     
@@ -168,7 +168,7 @@
                             <p class="text-gray-600 text-sm mb-4">
                                 クラウド導入から活用、最適化まで、お客様のDXを強力に推進します。
                             </p>
-                            <a href="#" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
+                            <a href="pages/jigyounaiyou.html#cloud" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
                         </div>
                     </div>
                     
@@ -179,7 +179,7 @@
                             <p class="text-gray-600 text-sm mb-4">
                                 データ分析からAIモデル開発まで、お客様の潜在的な価値を最大化します。
                             </p>
-                            <a href="#" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
+                            <a href="pages/jigyounaiyou.html#data-ai" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
                         </div>
                     </div>
                     
@@ -190,7 +190,7 @@
                             <p class="text-gray-600 text-sm mb-4">
                                 高度なセキュリティ技術と知見で、お客様の事業活動をあらゆる脅威から守ります。
                             </p>
-                            <a href="#" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
+                            <a href="pages/jigyounaiyou.html#security" class="font-semibold text-accent-blue group-hover:underline">詳細を見る</a>
                         </div>
                     </div>
                 </div>
@@ -215,21 +215,21 @@
                         <p class="text-gray-200">
                             代表取締役からのご挨拶と、当社のビジョン・ミッションをご紹介します。
                         </p>
-                        <a href="#" class="inline-block mt-4 text-white hover:underline">詳細はこちら</a>
+                        <a href="pages/kigyoujyouhou.html#top-message" class="inline-block mt-4 text-white hover:underline">詳細はこちら</a>
                     </div>
                     <div class="bg-blue-900 bg-opacity-50 p-6 rounded-lg shadow-lg">
                         <h3 class="text-2xl font-bold text-accent-blue mb-3">会社概要</h3>
                         <p class="text-gray-200">
                             設立年月日、資本金などの基本情報をご覧いただけます。
                         </p>
-                        <a href="#" class="inline-block mt-4 text-white hover:underline">詳細はこちら</a>
+                        <a href="pages/kigyoujyouhou.html#company-outline" class="inline-block mt-4 text-white hover:underline">詳細はこちら</a>
                     </div>
                     <div class="bg-blue-900 bg-opacity-50 p-6 rounded-lg shadow-lg">
                         <h3 class="text-2xl font-bold text-accent-blue mb-3">沿革</h3>
                         <p class="text-gray-200">
                             Sayo Social Connectのこれまでの歩みをご紹介します。
                         </p>
-                        <a href="#" class="inline-block mt-4 text-white hover:underline">詳細はこちら</a>
+                        <a href="pages/kigyoujyouhou.html#history" class="inline-block mt-4 text-white hover:underline">詳細はこちら</a>
                     </div>
                 </div>
             </div>
@@ -250,14 +250,14 @@
                         <p class="text-gray-700 mb-4">
                             豊富な知識を経験を最大限活かし、お客様の必要とするコードを迅速にご提供・ご開発できるように支援いたします。
                         </p>
-                        <a href="#" class="font-semibold text-accent-blue hover:underline">詳細を見る &rarr;</a>
+                        <a href="pages/solucion.html#dev-support" class="font-semibold text-accent-blue hover:underline">詳細を見る &rarr;</a>
                     </div>
                     <div class="p-6 bg-white rounded-lg shadow-lg">
                         <h3 class="text-2xl font-bold text-heavy-blue mb-3">システム開発・運用</h3>
                         <p class="text-gray-700 mb-4">
                             要件定義から設計、開発、テスト、そして運用保守まで、ライフサイクル全体にわたる高品質なシステム開発を提供します。お客様のニーズに合わせた柔軟な開発体制で、ビジネスを支えます。
                         </p>
-                        <a href="#" class="font-semibold text-accent-blue hover:underline">詳細を見る &rarr;</a>
+                        <a href="pages/solucion.html#system-dev" class="font-semibold text-accent-blue hover:underline">詳細を見る &rarr;</a>
                     </div>
                 </div>
             </div>
@@ -285,51 +285,52 @@
 
     <!-- 8. フッター --><footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <!-- ロゴ・住所 --><div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
-                    
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
-                
-                <!-- サイトマップ 1 --><div>
+
+                <div>
                     <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="#" class="hover:text-white">会社概要</a></li>
-                        <li><a href="#" class="hover:text-white">沿革</a></li>
-                        <!--<li><a href="#" class="hover:text-white">拠点一覧</a></li>--><!--なんか、ネタを思いついたら書き加える-->
+                        <li><a href="pages/kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="pages/kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="pages/kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="pages/kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
 
-                <!-- サイトマップ 2 --><div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <!--
-                        <li><a href="#" class="hover:text-white">エンタープライズソリューション</a></li>
-                        <li><a href="#" class="hover:text-white">クラウドインテグレーション</a></li>
-                        <li><a href="#" class="hover:text-white">データサイエンス・AI</a></li>
-                        <li><a href="#" class="hover:text-white">セキュリティコンサルティング</a></li>
-                         -->
+                        <li><a href="pages/jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="pages/jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="pages/jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
                     </ul>
                 </div>
-                
-                <!-- サイトマップ 3 --><div>
+
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="pages/solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="pages/solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="pages/solucion.html#case-study" class="hover:text-white">導入事例</a></li>
+                    </ul>
+                </div>
+
+                <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
                         <li><a href="#news" class="hover:text-white">お知らせ</a></li>
-                        <li><a href="#" class="hover:text-white">採用情報</a></li>
-                        <li><a href="#" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="pages/saiyou.html" class="hover:text-white">採用情報</a></li>
+                        <li><a href="pages/toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>
-            
+
             <div class="border-t border-gray-700 pt-8 mt-8 flex flex-col md:flex-row justify-between items-center">
-                <!--
-                <div class="text-sm space-x-4 mb-4 md:mb-0">
-                    <a href="#" class="hover:text-white">サイトポリシー</a>
-                    <a href="#" class="hover:text-white">プライバシーポリシー</a>
-                </div>
-                -->
                 <p class="text-sm text-gray-500">
                     &copy; 2025 SSC Sayo Social Connect, Inc. (Demo)
                 </p>

--- a/pages/KOKOKARA_KOPI-SITETUKAU.html
+++ b/pages/KOKOKARA_KOPI-SITETUKAU.html
@@ -53,7 +53,7 @@
 
                 <!-- PC向けナビゲーション (お問い合わせのみ残す) -->
                 <nav class="hidden md:flex md:items-center md:space-x-8">
-                    <a href="#contact" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
+                    <a href="toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
                         お問い合わせ
                     </a>
                 </nav>
@@ -75,7 +75,7 @@
             <a href="jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="#contact" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -101,39 +101,47 @@
     <!-- 8. フッター -->
     <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <!-- ロゴ・住所 -->
-                <div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
 
-                <!-- サイトマップ 1 -->
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="#" class="hover:text-white">会社概要</a></li>
-                        <li><a href="#" class="hover:text-white">沿革</a></li>
-                        <li><a href="#" class="hover:text-white">拠点一覧</a></li>
+                        <li><a href="kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
 
-                <!-- サイトマップ 2 -->
                 <div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">システム開発</a></li>
-                        <li><a href="#" class="hover:text-white">インフラ構築</a></li>
+                        <li><a href="jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
                     </ul>
                 </div>
 
-                <!-- サイトマップ 3 -->
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="solucion.html#case-study" class="hover:text-white">導入事例</a></li>
+                    </ul>
+                </div>
+
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#news" class="hover:text-white">お知らせ</a></li>
+                        <li><a href="../index.html#news" class="hover:text-white">お知らせ</a></li>
                         <li><a href="saiyou.html" class="hover:text-white">採用情報</a></li>
-                        <li><a href="#" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>

--- a/pages/jigyounaiyou.html
+++ b/pages/jigyounaiyou.html
@@ -46,7 +46,7 @@
                     </a>
                 </div>
                 <nav class="hidden md:flex md:items-center md:space-x-8">
-                    <a href="#contact" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
+                    <a href="toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
                         お問い合わせ
                     </a>
                 </nav>
@@ -62,7 +62,7 @@
             <a href="jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="#contact" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -93,7 +93,7 @@
         </div>
 
         <!-- 1. エンタープライズ・ソリューション -->
-        <section class="py-20 border-b border-gray-100">
+        <section id="enterprise" class="py-20 border-b border-gray-100">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
                 <div class="flex flex-col md:flex-row items-start gap-6 mb-12">
                     <div class="bg-heavy-blue text-white p-4 rounded-lg shrink-0">
@@ -145,7 +145,7 @@
         </section>
 
         <!-- 2. クラウドインテグレーション -->
-        <section class="py-20 bg-gray-50 border-b border-gray-100">
+        <section id="cloud" class="py-20 bg-gray-50 border-b border-gray-100">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
                 <div class="flex flex-col md:flex-row items-start gap-6 mb-12">
                     <div class="bg-accent-blue text-white p-4 rounded-lg shrink-0">
@@ -205,7 +205,7 @@
         </section>
 
         <!-- 3. データサイエンス・AI -->
-        <section class="py-20 border-b border-gray-100">
+        <section id="data-ai" class="py-20 border-b border-gray-100">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
                 <div class="flex flex-col md:flex-row items-start gap-6 mb-12">
                     <div class="bg-purple-600 text-white p-4 rounded-lg shrink-0">
@@ -243,7 +243,7 @@
         </section>
 
         <!-- 4. セキュリティコンサルティング -->
-        <section class="py-20 bg-gray-900 text-white">
+        <section id="security" class="py-20 bg-gray-900 text-white">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
                 <div class="flex flex-col md:flex-row items-start gap-6 mb-12">
                     <div class="bg-red-600 text-white p-4 rounded-lg shrink-0">
@@ -288,7 +288,7 @@
                 <p class="text-blue-200 mb-10 text-lg">
                     SSCにお任せください。責任を持って（だいたい）やり遂げます！
                 </p>
-                <a href="#contact" class="inline-block bg-white text-heavy-blue font-bold py-4 px-12 rounded-full hover:bg-gray-100 transition duration-300 shadow-lg text-lg">
+                <a href="toiawase.html" class="inline-block bg-white text-heavy-blue font-bold py-4 px-12 rounded-full hover:bg-gray-100 transition duration-300 shadow-lg text-lg">
                     恐れずに問い合わせる
                 </a>
             </div>
@@ -299,33 +299,43 @@
     <!-- 8. フッター -->
     <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="#" class="hover:text-white">会社概要</a></li>
-                        <li><a href="#" class="hover:text-white">沿革</a></li>
-                        <li><a href="#" class="hover:text-white">拠点一覧</a></li>
+                        <li><a href="kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
                 <div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">エンタープライズ</a></li>
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">クラウドインテグレーション</a></li>
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">AI・データサイエンス</a></li>
+                        <li><a href="jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="solucion.html#case-study" class="hover:text-white">導入事例</a></li>
                     </ul>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#news" class="hover:text-white">お知らせ</a></li>
+                        <li><a href="../index.html#news" class="hover:text-white">お知らせ</a></li>
                         <li><a href="saiyou.html" class="hover:text-white">採用情報</a></li>
-                        <li><a href="#" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>

--- a/pages/kigyoujyouhou.html
+++ b/pages/kigyoujyouhou.html
@@ -53,7 +53,7 @@
 
                 <!-- PC向けナビゲーション (お問い合わせのみ残す) -->
                 <nav class="hidden md:flex md:items-center md:space-x-8">
-                    <a href="#contact" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
+                    <a href="toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
                         お問い合わせ
                     </a>
                 </nav>
@@ -75,7 +75,7 @@
             <a href="jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="#contact" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -105,7 +105,7 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-24">
 
             <!-- 企業理念 -->
-            <section class="max-w-4xl mx-auto text-center">
+            <section id="philosophy" class="max-w-4xl mx-auto text-center">
                 <div class="mb-8">
                     <span class="text-accent-blue font-bold tracking-widest text-sm uppercase">Philosophy</span>
                     <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mt-2">企業理念</h2>
@@ -129,7 +129,7 @@
             </section>
 
             <!-- 代表挨拶（追加セクション） -->
-            <section class="max-w-5xl mx-auto">
+            <section id="top-message" class="max-w-5xl mx-auto">
                 <div class="mb-10 border-l-4 border-heavy-blue pl-4">
                     <span class="text-accent-blue font-bold tracking-widest text-sm uppercase block mb-1">Top Message</span>
                     <h2 class="text-2xl md:text-3xl font-bold text-gray-900">代表挨拶</h2>
@@ -175,7 +175,7 @@
             </section>
 
             <!-- 企業情報（表敬式・テーブルレイアウト） -->
-            <section class="max-w-4xl mx-auto">
+            <section id="company-outline" class="max-w-4xl mx-auto">
                 <div class="mb-8 border-l-4 border-heavy-blue pl-4">
                     <h2 class="text-2xl md:text-3xl font-bold text-gray-900">会社概要</h2>
                 </div>
@@ -224,7 +224,7 @@
             </section>
 
             <!-- 沿革 -->
-            <section class="max-w-4xl mx-auto">
+            <section id="history" class="max-w-4xl mx-auto">
                 <div class="mb-8 border-l-4 border-heavy-blue pl-4">
                     <h2 class="text-2xl md:text-3xl font-bold text-gray-900">沿革</h2>
                 </div>
@@ -278,39 +278,47 @@
     <!-- 8. フッター -->
     <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <!-- ロゴ・住所 -->
-                <div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
 
-                <!-- サイトマップ 1 -->
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="#" class="hover:text-white">会社概要</a></li>
-                        <li><a href="#" class="hover:text-white">沿革</a></li>
-                        <li><a href="#" class="hover:text-white">拠点一覧</a></li>
+                        <li><a href="kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
 
-                <!-- サイトマップ 2 -->
                 <div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">システム開発</a></li>
-                        <li><a href="#" class="hover:text-white">インフラ構築</a></li>
+                        <li><a href="jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
                     </ul>
                 </div>
 
-                <!-- サイトマップ 3 -->
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="solucion.html#case-study" class="hover:text-white">導入事例</a></li>
+                    </ul>
+                </div>
+
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#news" class="hover:text-white">お知らせ</a></li>
+                        <li><a href="../index.html#news" class="hover:text-white">お知らせ</a></li>
                         <li><a href="saiyou.html" class="hover:text-white">採用情報</a></li>
-                        <li><a href="#" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>

--- a/pages/oshirase/2025-10-26-renewal.html
+++ b/pages/oshirase/2025-10-26-renewal.html
@@ -82,6 +82,43 @@
     </nav>
 
     <!-- メインコンテンツ --><main>
+        <section class="bg-gray-50 border-b border-gray-200">
+            <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+                <p class="text-sm font-semibold text-accent-blue tracking-[0.3em] mb-2">NEWS</p>
+                <h1 class="text-3xl md:text-4xl font-black text-heavy-blue mb-4">コーポレートサイトをリニューアルしました</h1>
+                <p class="text-gray-500 text-sm">2025年10月26日</p>
+            </div>
+        </section>
+
+        <article class="container mx-auto px-4 sm:px-6 lg:px-8 py-16 max-w-4xl space-y-10">
+            <div class="bg-white shadow-lg rounded-2xl p-8 md:p-12 border border-gray-100">
+                <p class="text-gray-600 leading-relaxed mb-6">
+                    日頃よりSSC Sayo Social Connect株式会社のウェブサイトをご覧いただきありがとうございます。
+                    このたび、情報の探しやすさとモバイルでの閲覧性を向上させるため、コーポレートサイトを全面的に刷新いたしました。
+                </p>
+                <ul class="list-disc list-inside space-y-3 text-gray-700">
+                    <li>事業・ソリューション・採用情報をシンプルなタブナビゲーションで横断できるようにしました。</li>
+                    <li>各ページのフッターに主要コンテンツへのショートカットを配置し、相互リンクを強化しました。</li>
+                    <li>スマートフォンやタブレットからのアクセスでも快適に閲覧いただけるよう、レイアウトとタイポグラフィを最適化しました。</li>
+                </ul>
+                <p class="text-gray-600 leading-relaxed mt-6">
+                    今回のリニューアルにより、SSCが提供するサービスやソリューションをより身近に感じていただければ幸いです。
+                    今後とも変わらぬご愛顧のほど、よろしくお願い申し上げます。
+                </p>
+            </div>
+
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between bg-heavy-blue text-white rounded-2xl p-8 shadow-lg">
+                <div>
+                    <p class="text-sm uppercase tracking-[0.3em] text-blue-200 mb-1">Contact</p>
+                    <h2 class="text-2xl font-bold">ご意見・ご質問はこちらまで</h2>
+                    <p class="text-blue-100 text-sm mt-2">リニューアルに関するフィードバックも歓迎しています。</p>
+                </div>
+                <a href="../toiawase.html" class="mt-6 md:mt-0 inline-flex items-center justify-center bg-white text-heavy-blue font-bold px-8 py-3 rounded-full shadow hover:bg-gray-100 transition">
+                    お問い合わせページへ
+                    <span class="ml-2">&rarr;</span>
+                </a>
+            </div>
+        </article>
     </main>
 
     <!-- 8. フッター --><footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">

--- a/pages/oshirase/index.html
+++ b/pages/oshirase/index.html
@@ -3,12 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>お知らせ | SSC Sayo Social Connect</title>
-    <!-- Tailwind CSS CDN --><script src="https://cdn.tailwindcss.com"></script>
-    <!-- Inter Font --><link rel="preconnect" href="https://fonts.googleapis.com">
+    <title>お知らせ一覧 | SSC Sayo Social Connect</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Noto+Sans+JP:wght@400;700;900&display=swap" rel="stylesheet">
-
     <style>
         body {
             font-family: 'Inter', 'Noto Sans JP', sans-serif;
@@ -17,41 +16,25 @@
         }
         .bg-heavy-blue { background-color: #002A5B; }
         .text-heavy-blue { color: #002A5B; }
-        .border-heavy-blue { border-color: #002A5B; }
-
-        .bg-accent-blue { background-color: #00A0E9; }
         .text-accent-blue { color: #00A0E9; }
-
-        .hero-gradient {
-            background: linear-gradient(90deg, #002A5B 0%, rgba(0, 42, 91, 0.8) 5%, rgba(0, 42, 91, 0.3) 10%);
-        }
-
-        .hero-background-image {
-            background-image: url('../../image/header_image.avif');
-            background-size: cover;
-            background-position: center;
-        }
     </style>
 </head>
 <body class="bg-white text-gray-800">
-
-    <!-- 1. ヘッダー --><header class="bg-white border-b border-gray-200 sticky top-0 z-50 shadow-sm">
+    <header class="bg-white border-b border-gray-200 sticky top-0 z-50 shadow-sm">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center h-20">
-                <!-- ロゴ --><div class="flex-shrink-0">
+                <div class="flex-shrink-0">
                     <a href="../../index.html" class="flex items-center">
                         <span class="text-2xl font-black text-heavy-blue">SSC |</span>
                         <span class="text-xl font-bold text-gray-700 ml-2">Sayo Social Connect</span>
                     </a>
                 </div>
-
-                <!-- PC向けナビゲーション --><nav class="hidden md:flex md:items-center md:space-x-8">
+                <nav class="hidden md:flex md:items-center md:space-x-8">
                     <a href="../toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300">
                         お問い合わせ
                     </a>
                 </nav>
-
-                <!-- モバイル向けメニューボタン --><div class="md:hidden">
+                <div class="md:hidden">
                     <button id="mobile-menu-button" class="text-gray-700 focus:outline-none">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
@@ -60,8 +43,7 @@
                 </div>
             </div>
         </div>
-
-        <!-- モバイル向けメニュー (非表示) --><div id="mobile-menu" class="hidden md:hidden bg-white shadow-lg">
+        <div id="mobile-menu" class="hidden md:hidden bg-white shadow-lg">
             <a href="../kigyoujyouhou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">企業情報</a>
             <a href="../jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="../solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
@@ -70,21 +52,49 @@
         </div>
     </header>
 
-    <!-- タブ形式のナビゲーション --><nav class="bg-heavy-blue text-white shadow-md">
+    <nav class="bg-heavy-blue text-white shadow-md">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-start md:justify-center space-x-0 md:space-x-8 overflow-x-auto py-3">
-                <a href="../kigyoujyouhou.html" class="block py-2 px-4 text-white hover:bg-blue-700 hover:text-white rounded-md transition duration-300 whitespace-nowrap">企業情報</a>
-                <a href="../jigyounaiyou.html" class="block py-2 px-4 text-white hover:bg-blue-700 hover:text-white rounded-md transition duration-300 whitespace-nowrap">事業内容</a>
-                <a href="../solucion.html" class="block py-2 px-4 text-white hover:bg-blue-700 hover:text-white rounded-md transition duration-300 whitespace-nowrap">ソリューション</a>
-                <a href="../saiyou.html" class="block py-2 px-4 text-white hover:bg-blue-700 hover:text-white rounded-md transition duration-300 whitespace-nowrap">採用情報</a>
+                <a href="../kigyoujyouhou.html" class="block py-2 px-4 text-white hover:bg-blue-700 rounded-md">企業情報</a>
+                <a href="../jigyounaiyou.html" class="block py-2 px-4 text-white hover:bg-blue-700 rounded-md">事業内容</a>
+                <a href="../solucion.html" class="block py-2 px-4 text-white hover:bg-blue-700 rounded-md">ソリューション</a>
+                <a href="../saiyou.html" class="block py-2 px-4 text-white hover:bg-blue-700 rounded-md">採用情報</a>
             </div>
         </div>
     </nav>
 
-    <!-- メインコンテンツ --><main>
+    <main>
+        <section class="bg-gray-50 border-b border-gray-200">
+            <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+                <p class="text-sm font-semibold text-accent-blue tracking-[0.3em] mb-2">NEWS</p>
+                <h1 class="text-3xl md:text-4xl font-black text-heavy-blue">お知らせ一覧</h1>
+                <p class="text-gray-500 text-sm mt-2">SSCが最近発信したトピックスを掲載しています。</p>
+            </div>
+        </section>
+
+        <section class="container mx-auto px-4 sm:px-6 lg:px-8 py-16 max-w-5xl">
+            <div class="space-y-6">
+                <article class="flex flex-col md:flex-row items-start gap-6 bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+                    <div class="text-sm font-semibold text-gray-500">2025.10.26</div>
+                    <div class="flex-1">
+                        <h2 class="text-xl font-bold text-heavy-blue mb-2">コーポレートサイトをリニューアルしました</h2>
+                        <p class="text-gray-600 text-sm mb-3">主要ページのナビゲーションとフッターを整理し、より使いやすい構成になりました。</p>
+                        <a href="2025-10-26-renewal.html" class="text-accent-blue font-semibold hover:underline">記事を読む &rarr;</a>
+                    </div>
+                </article>
+                <article class="flex flex-col md:flex-row items-start gap-6 bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+                    <div class="text-sm font-semibold text-gray-500">2025.10.16</div>
+                    <div class="flex-1">
+                        <h2 class="text-xl font-bold text-heavy-blue mb-2">新サービス「城上コードメモ」を提供開始</h2>
+                        <p class="text-gray-600 text-sm mb-3">エンジニア向けのナレッジ共有プラットフォームがスタートしました。</p>
+                        <a href="2025-9-16-CM.html" class="text-accent-blue font-semibold hover:underline">記事を読む &rarr;</a>
+                    </div>
+                </article>
+            </div>
+        </section>
     </main>
 
-    <!-- 8. フッター --><footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
+    <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
                 <div class="lg:col-span-2 space-y-3">
@@ -134,10 +144,9 @@
         </div>
     </footer>
 
-    <!-- モバイルメニュー用スクリプト --><script>
+    <script>
         const menuButton = document.getElementById('mobile-menu-button');
         const mobileMenu = document.getElementById('mobile-menu');
-
         menuButton.addEventListener('click', () => {
             mobileMenu.classList.toggle('hidden');
         });

--- a/pages/saiyou.html
+++ b/pages/saiyou.html
@@ -105,7 +105,7 @@
 
                 <!-- PC向けナビゲーション -->
                 <nav class="hidden md:flex md:items-center md:space-x-8">
-                    <a href="#contact" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300">
+                    <a href="toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300">
                         お問い合わせ
                     </a>
                 </nav>
@@ -127,7 +127,7 @@
             <a href="jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="#contact" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -327,31 +327,43 @@
     <!-- 8. フッター -->
     <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8 relative z-20">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
                 <div>
-                    <h5  class="text-gray-400 font-semibold mb-3">企業情報</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="#" class="hover:text-white">会社概要</a></li>
-                        <li><a href="#" class="hover:text-white">沿革</a></li>
-                        <li><a href="#" class="hover:text-white">拠点一覧</a></li>
+                        <li><a href="kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
                 <div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <!-- <li><a href="#" class="hover:text-white">エンタープライズソリューション</a></li> -->
+                        <li><a href="jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="solucion.html#case-study" class="hover:text-white">導入事例</a></li>
                     </ul>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#news" class="hover:text-white">お知らせ</a></li>
-                        <li><a href="#" class="hover:text-white">採用情報</a></li>
-                        <li><a href="#" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="../index.html#news" class="hover:text-white">お知らせ</a></li>
+                        <li><a href="saiyou.html" class="hover:text-white">採用情報</a></li>
+                        <li><a href="toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>

--- a/pages/solucion.html
+++ b/pages/solucion.html
@@ -57,7 +57,7 @@
                     </a>
                 </div>
                 <nav class="hidden md:flex md:items-center md:space-x-8">
-                    <a href="#contact" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
+                    <a href="toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
                         お問い合わせ
                     </a>
                 </nav>
@@ -73,7 +73,7 @@
             <a href="jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="#contact" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -104,7 +104,7 @@
         </div>
 
         <!-- 1. コード開発支援 -->
-        <section class="py-20 border-b border-gray-100">
+        <section id="dev-support" class="py-20 border-b border-gray-100">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
                 <div class="mb-12 text-center">
                     <span class="text-accent-blue font-bold tracking-widest text-sm uppercase">Development Support</span>
@@ -161,7 +161,7 @@
         </section>
 
         <!-- 2. システム開発・運用 -->
-        <section class="py-20 bg-slate-50 border-b border-gray-100">
+        <section id="system-dev" class="py-20 bg-slate-50 border-b border-gray-100">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
                 <div class="mb-12 text-center">
                     <span class="text-accent-blue font-bold tracking-widest text-sm uppercase">System Integration</span>
@@ -200,7 +200,7 @@
         </section>
 
         <!-- 3. 事例紹介（調整中） -->
-        <section class="py-24 bg-white relative overflow-hidden">
+        <section id="case-study" class="py-24 bg-white relative overflow-hidden">
             <!-- 背景の工事現場テープ -->
             <div class="absolute inset-0 opacity-5 pointer-events-none">
                 <div class="absolute top-0 left-0 w-[200%] h-20 bg-black -rotate-3 origin-top-left transform translate-y-10 translate-x-[-10%] construction-stripe"></div>
@@ -238,7 +238,7 @@
                 <p class="text-blue-200 mb-10 text-lg">
                     運が良ければ、すぐに解決します。
                 </p>
-                <a href="#contact" class="inline-block bg-white text-heavy-blue font-bold py-4 px-12 rounded-full hover:bg-gray-100 transition duration-300 shadow-lg text-lg group">
+                <a href="toiawase.html" class="inline-block bg-white text-heavy-blue font-bold py-4 px-12 rounded-full hover:bg-gray-100 transition duration-300 shadow-lg text-lg group">
                     <span>運試しに問い合わせる</span>
                     <i class="fa-solid fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
                 </a>
@@ -250,33 +250,43 @@
     <!-- 8. フッター -->
     <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="kigyoujyouhou.html" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="kigyoujyouhou.html" class="hover:text-white">会社概要</a></li>
-                        <li><a href="kigyoujyouhou.html" class="hover:text-white">沿革</a></li>
-                        <li><a href="#" class="hover:text-white">拠点一覧</a></li>
+                        <li><a href="kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
                 <div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">エンタープライズ</a></li>
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">クラウドインテグレーション</a></li>
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">AI・データサイエンス</a></li>
+                        <li><a href="jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="solucion.html#case-study" class="hover:text-white">導入事例</a></li>
                     </ul>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#news" class="hover:text-white">お知らせ</a></li>
+                        <li><a href="../index.html#news" class="hover:text-white">お知らせ</a></li>
                         <li><a href="saiyou.html" class="hover:text-white">採用情報</a></li>
-                        <li><a href="#" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>

--- a/pages/toiawase.html
+++ b/pages/toiawase.html
@@ -67,7 +67,7 @@
                     </a>
                 </div>
                 <nav class="hidden md:flex md:items-center md:space-x-8">
-                    <a href="contact.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
+                    <a href="toiawase.html" class="bg-heavy-blue text-white px-5 py-2 rounded-full font-bold hover:bg-opacity-80 transition duration-300 shadow-md">
                         お問い合わせ
                     </a>
                 </nav>
@@ -83,7 +83,7 @@
             <a href="jigyounaiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">事業内容</a>
             <a href="solucion.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">ソリューション</a>
             <a href="saiyou.html" class="block px-4 py-3 text-gray-700 font-bold hover:bg-gray-100">採用情報</a>
-            <a href="contact.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
+            <a href="toiawase.html" class="block px-4 py-3 bg-heavy-blue text-white font-bold text-center m-2 rounded-full">お問い合わせ</a>
         </div>
     </header>
 
@@ -198,33 +198,43 @@
     <!-- 8. フッター -->
     <footer id="contact" class="bg-gray-900 text-gray-300 pt-16 pb-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-                <div>
-                    <h4 class="text-lg font-bold text-white mb-3">SSC Sayo Social Connect株式会社</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-8">
+                <div class="lg:col-span-2 space-y-3">
+                    <h4 class="text-lg font-bold text-white">SSC Sayo Social Connect株式会社</h4>
+                    <p class="text-sm text-gray-400">〒100-0000 首都中央市街第12区 第8ビル 22階</p>
+                    <p class="text-xs text-gray-500">SayoホールディングスのITソリューション企業です。</p>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">企業情報</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="kigyoujyouhou.html" class="hover:text-white">ご挨拶</a></li>
-                        <li><a href="kigyoujyouhou.html" class="hover:text-white">会社概要</a></li>
-                        <li><a href="kigyoujyouhou.html" class="hover:text-white">沿革</a></li>
-                        <li><a href="#" class="hover:text-white">拠点一覧</a></li>
+                        <li><a href="kigyoujyouhou.html#philosophy" class="hover:text-white">企業理念</a></li>
+                        <li><a href="kigyoujyouhou.html#top-message" class="hover:text-white">代表挨拶</a></li>
+                        <li><a href="kigyoujyouhou.html#company-outline" class="hover:text-white">会社概要</a></li>
+                        <li><a href="kigyoujyouhou.html#history" class="hover:text-white">沿革</a></li>
                     </ul>
                 </div>
                 <div>
-                    <h5 class="text-gray-400 font-semibold mb-3">事業・ソリューション</h5>
+                    <h5 class="text-gray-400 font-semibold mb-3">事業</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">エンタープライズ</a></li>
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">クラウドインテグレーション</a></li>
-                        <li><a href="jigyounaiyou.html" class="hover:text-white">AI・データサイエンス</a></li>
+                        <li><a href="jigyounaiyou.html#enterprise" class="hover:text-white">エンタープライズ</a></li>
+                        <li><a href="jigyounaiyou.html#cloud" class="hover:text-white">クラウド統合</a></li>
+                        <li><a href="jigyounaiyou.html#data-ai" class="hover:text-white">データサイエンス・AI</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h5 class="text-gray-400 font-semibold mb-3">ソリューション</h5>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="solucion.html#dev-support" class="hover:text-white">コード開発支援</a></li>
+                        <li><a href="solucion.html#system-dev" class="hover:text-white">システム開発・運用</a></li>
+                        <li><a href="solucion.html#case-study" class="hover:text-white">導入事例</a></li>
                     </ul>
                 </div>
                 <div>
                     <h5 class="text-gray-400 font-semibold mb-3">その他</h5>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="#news" class="hover:text-white">お知らせ</a></li>
+                        <li><a href="../index.html#news" class="hover:text-white">お知らせ</a></li>
                         <li><a href="saiyou.html" class="hover:text-white">採用情報</a></li>
-                        <li><a href="contact.html" class="hover:text-white">お問い合わせ</a></li>
+                        <li><a href="toiawase.html" class="hover:text-white">お問い合わせ</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- route every header and mobile contact button to `toiawase.html` and rebuild the global footer into dedicated 企業・事業・ソリューション・その他 columns so that cross-links are consistent site-wide
- add anchor IDs across the company, business, and solution detail pages and update home page cards/CTA buttons to jump to the relevant sections
- publish a renewal announcement and a compact news index page, then wire the top-page news list and 「お知らせ一覧」 link to those articles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc64448808320a4839b1ca65fff8a)